### PR TITLE
Add initial Python skeleton for ACUTIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ACUTIS
 
-ACUTIS is an early stage concept currently represented by a collection of project documents. This repository lays the groundwork for future development and organization of the idea.
+ACUTIS is an early stage concept currently represented by a collection of project documents and a small Python codebase. This repository lays the groundwork for future development and organization of the idea.
 
 ## Available Documents
 
@@ -10,17 +10,17 @@ ACUTIS is an early stage concept currently represented by a collection of projec
 - **Invention Disclosure Form** – preliminary intellectual property filing
 - **ProvisionalPatent ACUTIS** – provisional patent paperwork
 
-All documentation is provided as PDF files in the repository root. Additional notes can be kept inside the `docs/` directory.
+All documentation is provided as PDF or RTF files in the repository root. Additional notes can be kept inside the `docs/` directory.
 
 ## Repository Structure
 
 The following directories provide a starting framework:
 
 - `docs/` – supplementary design notes and references
-- `src/` – future source code
-- `tests/` – test materials for any code that will be added later
+- `src/` – Python source code for simulations and algorithms
+- `tests/` – unit tests for the Python modules
 
-This layout is intentionally minimal to keep the focus on concept exploration. Detailed implementation and scripts will come later as the project matures.
+The current code offers simple abstractions for hardware, collar control, data acquisition, and signal processing. These pieces are intentionally lightweight and will evolve as the project matures.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,3 @@
 # Documentation
 
-This folder contains notes and supplementary material for the ACUTIS concept. Place any design sketches, brainstorming notes or supporting references here as the project evolves.
+This folder contains notes and supplementary material for the ACUTIS concept. The file `architecture.md` gives a brief overview of the current software layout. Additional design sketches and references can be added here as the project evolves.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,12 @@
+# ACUTIS Architecture Overview
+
+This document outlines the initial architecture based on the high level plan. The goal is to provide a foundation for building an air-coupled ultrasonic inspection system.
+
+## Components
+
+- **Hardware Abstractions**: Classes representing transmitters, receivers, and mechanical movement.
+- **Data Acquisition**: Coordinates hardware elements and collects readings for each collar position.
+- **Processing**: Functions that analyze captured signals and extract useful metrics.
+- **Command Line Interface**: Entry points for running simple simulated scans and demonstrating the workflow.
+
+Future iterations will expand these components into full-featured modules that interact with real devices and provide sophisticated analysis.

--- a/src/README.md
+++ b/src/README.md
@@ -1,1 +1,4 @@
-Source code will be placed here once development begins.
+The `src` directory houses the Python package `acutis`. The package currently provides
+basic building blocks for simulating hardware and data collection routines. As the
+project grows, these modules will be expanded to control real equipment and perform
+more advanced signal analysis.

--- a/src/acutis/__init__.py
+++ b/src/acutis/__init__.py
@@ -1,0 +1,15 @@
+"""ACUTIS package initialization."""
+
+__all__ = [
+    "AirCoupledTransducer",
+    "CollarController",
+    "DataAcquisition",
+    "process_signal",
+]
+
+from .hardware import AirCoupledTransducer
+from .collar import CollarController
+from .data_acquisition import DataAcquisition
+from .processing import process_signal
+
+__version__ = "0.1.0"

--- a/src/acutis/cli.py
+++ b/src/acutis/cli.py
@@ -1,0 +1,43 @@
+"""Command line interface for running sample scans."""
+
+from __future__ import annotations
+
+import argparse
+from typing import List
+
+from .hardware import AirCoupledTransducer
+from .collar import CollarController
+from .data_acquisition import DataAcquisition
+from .processing import process_signal
+
+
+def run_scan(positions: List[float]) -> None:
+    """Run a simulated scan across the provided positions."""
+    tx = AirCoupledTransducer("TX")
+    rx = AirCoupledTransducer("RX")
+    collar = CollarController()
+    daq = DataAcquisition(tx, rx, collar)
+
+    readings = daq.scan_profile(positions)
+    result = process_signal(readings)
+    for pos, reading in zip(positions, readings):
+        print(f"position {pos:.2f} -> amplitude {reading:.3f}")
+    print(f"average amplitude: {result:.3f}")
+
+
+def main(args: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run a simulated ACUTIS scan")
+    parser.add_argument(
+        "positions",
+        metavar="P",
+        type=float,
+        nargs="+",
+        help="positions along the pole to scan",
+    )
+    ns = parser.parse_args(args)
+    run_scan(ns.positions)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/acutis/collar.py
+++ b/src/acutis/collar.py
@@ -1,0 +1,19 @@
+"""Control for the robotic utility inspection collar."""
+
+from __future__ import annotations
+
+
+class CollarController:
+    """Simple controller for vertical movement along a pole."""
+
+    def __init__(self) -> None:
+        self.position = 0.0
+
+    def move_to(self, position: float) -> None:
+        """Move the collar to the requested vertical position."""
+        self.position = position
+
+    def step(self, distance: float) -> None:
+        """Move the collar relative to the current position."""
+        self.position += distance
+

--- a/src/acutis/data_acquisition.py
+++ b/src/acutis/data_acquisition.py
@@ -1,0 +1,31 @@
+"""Data acquisition routines for ACUTIS."""
+
+from __future__ import annotations
+
+from .hardware import AirCoupledTransducer
+from .collar import CollarController
+
+
+class DataAcquisition:
+    """Coordinate collar movement and signal capture."""
+
+    def __init__(self, transmitter: AirCoupledTransducer, receiver: AirCoupledTransducer, collar: CollarController) -> None:
+        self.transmitter = transmitter
+        self.receiver = receiver
+        self.collar = collar
+
+    def scan_step(self, position: float) -> float:
+        """Move to position, transmit, and receive a single reading."""
+        self.collar.move_to(position)
+        self.transmitter.transmit_pulse()
+        amplitude = self.receiver.receive_echo()
+        return amplitude
+
+    def scan_profile(self, positions: list[float]) -> list[float]:
+        """Scan a series of positions and return their amplitudes."""
+        readings = []
+        for pos in positions:
+            reading = self.scan_step(pos)
+            readings.append(reading)
+        return readings
+

--- a/src/acutis/hardware.py
+++ b/src/acutis/hardware.py
@@ -1,0 +1,24 @@
+"""Hardware abstractions for the ACUTIS system."""
+
+from __future__ import annotations
+
+import random
+
+
+class AirCoupledTransducer:
+    """Simulated air-coupled ultrasonic transducer."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def transmit_pulse(self) -> None:
+        """Simulate transmitting an ultrasonic pulse."""
+        # In a real system, this would interface with hardware drivers.
+        pass
+
+    def receive_echo(self) -> float:
+        """Simulate receiving an echo with a random amplitude."""
+        # This placeholder returns a pseudo-random amplitude.
+        amplitude = random.uniform(0.0, 1.0)
+        return amplitude
+

--- a/src/acutis/processing.py
+++ b/src/acutis/processing.py
@@ -1,0 +1,16 @@
+"""Signal processing utilities for ACUTIS."""
+
+from __future__ import annotations
+
+from statistics import mean
+
+
+def process_signal(readings: list[float]) -> float:
+    """Very basic signal processing placeholder.
+
+    Calculates the mean amplitude of provided readings.
+    """
+    if not readings:
+        raise ValueError("No readings provided")
+    return mean(readings)
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,1 +1,5 @@
-Test cases and supporting utilities will appear here as code is added.
+This directory contains unit tests for the ACUTIS Python modules. Run the tests with:
+
+```
+python -m unittest discover -s tests
+```

--- a/tests/test_data_acquisition.py
+++ b/tests/test_data_acquisition.py
@@ -1,0 +1,20 @@
+import unittest
+
+from src.acutis.collar import CollarController
+from src.acutis.data_acquisition import DataAcquisition
+from src.acutis.hardware import AirCoupledTransducer
+
+
+class TestDataAcquisition(unittest.TestCase):
+    def test_scan_profile_length(self):
+        tx = AirCoupledTransducer("TX")
+        rx = AirCoupledTransducer("RX")
+        collar = CollarController()
+        daq = DataAcquisition(tx, rx, collar)
+        positions = [0, 1, 2, 3]
+        readings = daq.scan_profile(positions)
+        self.assertEqual(len(readings), len(positions))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,0 +1,17 @@
+import unittest
+
+from src.acutis.processing import process_signal
+
+
+class TestProcessing(unittest.TestCase):
+    def test_process_signal_average(self):
+        readings = [0.1, 0.2, 0.3]
+        self.assertAlmostEqual(process_signal(readings), 0.2)
+
+    def test_process_signal_empty(self):
+        with self.assertRaises(ValueError):
+            process_signal([])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- document the repository structure and architecture
- scaffold the `acutis` Python package with simple simulation modules
- provide a command line interface for running a mock scan
- add unit tests for processing and data acquisition

## Testing
- `python3 -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_685e257a3d48833388a20393a167fd69